### PR TITLE
Use affe-find as default find function instead of consult-find

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - consult-ghq
 
-Find repository files using [affe-find](https://github.com/minad/affe), similar to consult-find.
+Select a repository from the [ghq](https://github.com/x-motemen/ghq) list and then find repository files using [affe-find](https://github.com/minad/affe) (similar to consult-find).
 
 If you want to use consult-find instead, you can change like bellow:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# consult-ghq - Ghq interface using consult
+# consult-ghq: Ghq interface using consult
 
 ## Command
 

--- a/README.md
+++ b/README.md
@@ -4,4 +4,10 @@
 
 - consult-ghq
 
-Find repository files using consult-find
+Find repository files using [affe-find](https://github.com/minad/affe), similar to consult-find.
+
+If you want to use consult-find instead, you can change like bellow:
+
+```elisp
+(setq consult-ghq-find-function #'consult-find)
+```

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -74,7 +74,7 @@
 (defun consult-ghq ()
   "Find file from selected repo using ghq."
   (interactive)
-  (let* ((repo (consult--read (consult-ghq--list-candidates) :prompt "Find repo: "))
+  (let* ((repo (consult--read (consult-ghq--list-candidates) :prompt "Repo: "))
         (default-directory repo))
     (funcall consult-ghq-find-function repo)))
 

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -69,7 +69,8 @@
 (defun consult-ghq ()
   "Find file from selected repo using ghq."
   (interactive)
-  (let ((repo (consult--read (consult-ghq--list-candidates) :prompt "Find repo: ")))
+  (let* ((repo (consult--read (consult-ghq--list-candidates) :prompt "Find repo: "))
+        (default-directory repo))
     (funcall consult-ghq-find-function repo)))
 
 (provide 'consult-ghq)

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -43,6 +43,11 @@
   :type 'string
   :group 'consult-ghq)
 
+(defcustom consult-ghq-find-function #'consult-find
+  "Find function that find files after selected repo."
+  :type 'function
+  :group 'consult-ghq)
+
 (defun consult-ghq--list-candidates ()
   "Return ghq list candidate."
   (with-temp-buffer
@@ -65,7 +70,7 @@
   "Find file from selected repo using ghq."
   (interactive)
   (let ((repo (consult--read (consult-ghq--list-candidates) :prompt "Find repo: ")))
-    (consult-find repo)))
+    (funcall consult-ghq-find-function repo)))
 
 (provide 'consult-ghq)
 

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2021 Tomoya Otake
 
 ;; Author: Tomoya Otake <tomoya.ton@gmail.com>
-;; Version: 0.0.1
+;; Version: 0.0.2
 ;; Homepage: https://github.com/tomoya/consult-ghq
 ;; Keywords: convenience, usability, consult, ghq
 ;; Package-Requires: ((emacs "26.1") (consult "0.8") (affe "0.1"))

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -26,7 +26,11 @@
 
 ;; This packaage provides qhq interface using Consult.
 ;;
-;; Its main entry points are the commands `consult-ghq'.
+;; Its main entry points are the commands `consult-ghq'.  Default
+;; find-function is affe-find.  If you want to use consult-find
+;; instead, you can change like bellow:
+;;
+;; (setq consult-ghq-find-function #'consult-find)
 
 ;;; Code:
 

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -6,7 +6,7 @@
 ;; Version: 0.0.1
 ;; Homepage: https://github.com/tomoya/consult-ghq
 ;; Keywords: convenience, usability, consult, ghq
-;; Package-Requires: ((emacs "26.1") (consult "0.8"))
+;; Package-Requires: ((emacs "26.1") (consult "0.8") (affe "0.1"))
 ;; License: GPL-3.0-or-later
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -31,6 +31,7 @@
 ;;; Code:
 
 (require 'consult)
+(require 'affe)
 
 (defgroup consult-ghq nil
   "Ghq interface using consult."
@@ -43,7 +44,7 @@
   :type 'string
   :group 'consult-ghq)
 
-(defcustom consult-ghq-find-function #'consult-find
+(defcustom consult-ghq-find-function #'affe-find
   "Find function that find files after selected repo."
   :type 'function
   :group 'consult-ghq)


### PR DESCRIPTION
- Use affe-find instead of consult-find
- Define consult-ghq-find-function to switch find function
- Version bump to 0.0.2
- Change short prompt string
- Update document

