### PR TITLE
Use nreverse to improve performance

### DIFF
--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -73,7 +73,7 @@
           (line-beginning-position) (line-end-position))
          paths)
         (forward-line 1))
-      (reverse paths))))
+      (nreverse paths))))
 
 ;;;###autoload
 (defun consult-ghq-find ()

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2021 Tomoya Otake
 
 ;; Author: Tomoya Otake <tomoya.ton@gmail.com>
-;; Version: 0.0.3
+;; Version: 0.0.4
 ;; Homepage: https://github.com/tomoya/consult-ghq
 ;; Keywords: convenience, usability, consult, ghq
 ;; Package-Requires: ((emacs "26.1") (consult "0.8") (affe "0.1"))


### PR DESCRIPTION
Use `nreverse` instead of `reverse` to improve performance.  Thank you advise @conao3