### PR TITLE
Add consult-ghq-switch-project function

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ Also, you can change grep function like bellow:
 ```elisp
 (setq consult-ghq-grep-function #'consult-grep)
 ```
+
+### consult-ghq-switch-project
+
+Select a project from the ghq list and then switch to it via project.el (default) or projectile
+
+You can change switch project function like below:
+
+```elisp
+(setq consult-ghq-switch-project-function #'projectile-switch-project)
+```

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -58,6 +58,11 @@
   :type 'function
   :group 'consult-ghq)
 
+(defcustom consult-ghq-switch-project-function #'project-switch-project
+  "Switch project function that opens a project in that project manager."
+  :type 'function
+  :group 'consult-ghq)
+
 (defun consult-ghq--list-candidates ()
   "Return ghq list candidate."
   (with-temp-buffer
@@ -90,6 +95,13 @@
   (let* ((repo (consult--read (consult-ghq--list-candidates) :prompt "Repo: "))
          (default-directory repo))
     (funcall consult-ghq-grep-function repo)))
+
+;;;###autoload
+(defun consult-ghq-switch-project ()
+  "Switch project from ghq."
+  (interactive)
+  (let ((repo (consult--read (consult-ghq--list-candidates) :prompt "Repo: ")))
+    (funcall consult-ghq-switch-project-function repo)))
 
 (provide 'consult-ghq)
 


### PR DESCRIPTION
Both project.el and projectile maintain their own project lists, which is a bit annoying if I want to open the project I just cloned, as they don't know about it yet.

This PR adds a function to let ghq find the projects instead.