### PR TITLE
Make affe optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This packaage provides these commands.
 
 ### consult-ghq-find
 
-Select a repository from the [ghq](https://github.com/x-motemen/ghq) list and then find repository files using [affe-find](https://github.com/minad/affe) (similar to consult-find).
+Select a repository from the [ghq](https://github.com/x-motemen/ghq) list and then find repository files using [affe-find](https://github.com/minad/affe) (if installed) or consult-find.
 
-If you want to use consult-find instead, you can change like below:
+If you want to use consult-find despite having affe installed, you can change like below:
 
 ```elisp
 (setq consult-ghq-find-function #'consult-find)

--- a/consult-ghq.el
+++ b/consult-ghq.el
@@ -6,7 +6,7 @@
 ;; Version: 0.0.4
 ;; Homepage: https://github.com/tomoya/consult-ghq
 ;; Keywords: convenience, usability, consult, ghq
-;; Package-Requires: ((emacs "26.1") (consult "0.8") (affe "0.1"))
+;; Package-Requires: ((emacs "26.1") (consult "0.8"))
 ;; License: GPL-3.0-or-later
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -27,15 +27,15 @@
 ;; This packaage provides ghq interface using Consult.
 ;;
 ;; Its main entry points are the commands `consult-ghq-find' and
-;; `consult-ghq-grep`.  Default find-function is affe-find.  If you
-;; want to use consult-find instead, you can change like below:
+;; `consult-ghq-grep`.  Default find-function is affe-find, if it's
+;; installed, otherwise consult-find.  If you want to use consult-find
+;; despite having affe installed, you can change like below:
 ;;
 ;; (setq consult-ghq-find-function #'consult-find)
 
 ;;; Code:
 
 (require 'consult)
-(require 'affe)
 
 (defgroup consult-ghq nil
   "Ghq interface using consult."
@@ -48,12 +48,16 @@
   :type 'string
   :group 'consult-ghq)
 
-(defcustom consult-ghq-find-function #'affe-find
+(defcustom consult-ghq-find-function (if (fboundp 'affe-find)
+                                         #'affe-find
+                                       #'consult-find)
   "Find function that find files after selected repo."
   :type 'function
   :group 'consult-ghq)
 
-(defcustom consult-ghq-grep-function #'affe-grep
+(defcustom consult-ghq-grep-function (if (fboundp 'affe-grep)
+                                         #'affe-grep
+                                       #'consult-grep)
   "Grep function that find files after selected repo."
   :type 'function
   :group 'consult-ghq)


### PR DESCRIPTION
This PR relaxes the dependency on affe, using it if it's already installed, otherwise falling back to consult.

Affe is an experimental package according to [its own readme](https://github.com/minad/affe/blob/ae3169ac4bbd64520d165b4ce4806b7a34b972dc/README.org#L21-L25), so in my _opinion_, it should not be a default.  Nevertheless, I made it so that affe will be used by default if it's already installed.
